### PR TITLE
Add option to automatically deploy Marathon Load Balancers

### DIFF
--- a/Api.groovy
+++ b/Api.groovy
@@ -11,7 +11,12 @@ import groovy.json.JsonOutput
 class Api {
 
     def baseUrl
+    def http
 
+    def init (appBaseUrl) {
+        baseUrl = appBaseUrl
+        http = new HTTPBuilder (baseUrl)
+    }
 
     /* ----------------------------- App Stuff ----------------------------- */
 
@@ -23,7 +28,6 @@ class Api {
         //    the data is valid. Maybe warn if p does not contain:
         //    cpu, mem, container.docker.image, constraints
 
-        def http = new HTTPBuilder (baseUrl)
         def postBody = deployAppBodyBuilder (p)
         println (postBody)
         try {
@@ -115,7 +119,6 @@ class Api {
     // Restart an app by the appId
     def restartApp (appId) {
         // 'appId' is the properties.appId used to create the app
-        def http = new HTTPBuilder (baseUrl)
 
         try {
             http.request (POST, JSON) { req ->
@@ -139,8 +142,6 @@ class Api {
     def destroyApp (appId) {
         // 'appId' is the properties.appId used to create the app
 
-        def http = new HTTPBuilder (baseUrl)
-
         try {
             http.request (DELETE) {
                 uri.path = '/marathon/v2/apps/' + appId
@@ -163,8 +164,6 @@ class Api {
         // 'appId' is the properties.appId used to create the app
         // 'numInstances' is the number of instances to which the app will be scaled
         
-        def http = new HTTPBuilder (baseUrl)
-
         def postBody = [
             cmd: 'sleep 55',
             instances: numInstances
@@ -210,7 +209,6 @@ class Api {
         //    the data is valid. Maybe warn if p does not contain:
         //    cpu, mem, container.docker.image, constraints
 
-        def http = new HTTPBuilder (baseUrl)
         def postBody
 
         if (type == 'external') {
@@ -240,10 +238,7 @@ class Api {
     }
 
     // Read the configuration for a load balancer from json file
-    def deployLoadBalancerBodyBuilder (p) {
-        def postBody = new File('marathon-lb-external.json').text
-        return postBody
-    }
+    def deployLoadBalancerBodyBuilder (p) {}
 
 
 

--- a/Api.groovy
+++ b/Api.groovy
@@ -12,7 +12,7 @@ class Api {
 
     def baseUrl
     def http
-    def autoDeployMLB
+    def autoDeployMLB   // MLB == Marathon Load Balancer
 
     def init (appBaseUrl, appAutoDeployMLB) {
         baseUrl = appBaseUrl

--- a/Demo.groovy
+++ b/Demo.groovy
@@ -1,0 +1,81 @@
+
+package myPackage
+
+app = new Api()
+app.baseUrl = 'http://localhost'
+
+// Mongo app for testing
+def appProperties = [
+    appId: 'mongo',
+    appCpus: 0.1,
+    appMem: 128,
+    appInstances: 1,
+    appImage: 'mongo',
+    appContainerPort: 27017,
+    appHostPort: 0,
+    appServicePort: 0,
+    appHaproxyGroup: 'internal'
+]
+
+    // removed from above:
+        // appCmd: 'env && sleep 300',
+        // appEnv: [
+        //     LD_LIBRARY_PATH: '/usr/local/lib/myLib',
+        //     HA_HE_HE_HA: '/usr/lol/no/thx'
+        // ],
+        // appAcceptResourceRoles: [
+        //     'role1', '*'
+        // ],
+        // appLabels: [
+        //     environment: 'staging'
+        // ]
+        
+// Test scaling by scaling up to <scaleUp> instances
+def scaleUp = 5 
+def groupProperties = [
+    [
+        appId: 'mongooble',
+        appCpus: 0.1,
+        appMem: 256,
+        appInstances: 1,
+        appImage: 'mongo',
+        appContainerPort: 0,
+        appHostPort: 0,
+        appServicePort: 0,
+        appHaproxyGroup: 'internal'
+    ],
+    [
+        appId: 'mongoblet',
+        appCpus: 0.1,
+        appMem: 256,
+        appInstances: 1,
+        appImage: 'mongo',
+        appContainerPort: 0,
+        appHostPort: 0,
+        appServicePort: 0,
+        appHaproxyGroup: 'internal',
+    ]
+]
+
+// Deploy Mongo app set in properties above
+// app.deployApp(appProperties)
+
+// Wait to restart to Marathon doesn't get mad
+sleep(1000)
+
+// Restart Mongo app
+//app.restartApp(appProperties.appId)
+
+//sleep(5000)
+
+//app.scaleApp(appProperties.appId, scaleUp)
+
+//sleep(5000)
+
+// Delete Mongo app
+//app.destroyApp(appProperties.appId)
+
+app.deployApp(appProperties)
+app.deployLoadBalancer('external')
+app.deployLoadBalancer('internal')
+

--- a/Demo.groovy
+++ b/Demo.groovy
@@ -1,11 +1,10 @@
-
 package myPackage
 
 app = new Api()
-app.baseUrl = 'http://localhost'
+app.init('http://localhost', true)
 
 // Mongo app for testing
-def appProperties = [
+def mongoProperties = [
     appId: 'mongo',
     appCpus: 0.1,
     appMem: 128,
@@ -13,69 +12,23 @@ def appProperties = [
     appImage: 'mongo',
     appContainerPort: 27017,
     appHostPort: 0,
-    appServicePort: 0,
+    appServicePort: 10001,
     appHaproxyGroup: 'internal'
 ]
 
-    // removed from above:
-        // appCmd: 'env && sleep 300',
-        // appEnv: [
-        //     LD_LIBRARY_PATH: '/usr/local/lib/myLib',
-        //     HA_HE_HE_HA: '/usr/lol/no/thx'
-        // ],
-        // appAcceptResourceRoles: [
-        //     'role1', '*'
-        // ],
-        // appLabels: [
-        //     environment: 'staging'
-        // ]
-        
-// Test scaling by scaling up to <scaleUp> instances
-def scaleUp = 5 
-def groupProperties = [
-    [
-        appId: 'mongooble',
-        appCpus: 0.1,
-        appMem: 256,
-        appInstances: 1,
-        appImage: 'mongo',
-        appContainerPort: 0,
-        appHostPort: 0,
-        appServicePort: 0,
-        appHaproxyGroup: 'internal'
-    ],
-    [
-        appId: 'mongoblet',
-        appCpus: 0.1,
-        appMem: 256,
-        appInstances: 1,
-        appImage: 'mongo',
-        appContainerPort: 0,
-        appHostPort: 0,
-        appServicePort: 0,
-        appHaproxyGroup: 'internal',
-    ]
+def nodeProperties = [
+    appId: 'node-web-app',
+    appCpus: 0.1,
+    appMem: 128,
+    appInstances: 1,
+    appImage: 'amandabaker/node-web-app',
+    appContainerPort: 80,
+    appHostPort: 80,
+    appServicePort: 10000,
+    appHaproxyGroup: 'external'    
 ]
 
-// Deploy Mongo app set in properties above
-// app.deployApp(appProperties)
-
-// Wait to restart to Marathon doesn't get mad
-sleep(1000)
-
-// Restart Mongo app
-//app.restartApp(appProperties.appId)
-
-//sleep(5000)
-
-//app.scaleApp(appProperties.appId, scaleUp)
-
-//sleep(5000)
-
-// Delete Mongo app
-//app.destroyApp(appProperties.appId)
-
-app.deployApp(appProperties)
-app.deployLoadBalancer('external')
-app.deployLoadBalancer('internal')
+// Deploy a mongo and a node-web-app container, and loadBalancers if necessary
+app.deployApp (mongoProperties)
+app.deployApp (nodeProperties)
 

--- a/Main.groovy
+++ b/Main.groovy
@@ -2,7 +2,7 @@
 package myPackage
 
 app = new Api()
-app.baseUrl = 'http://localhost'
+app.init('http://localhost')
 
 // Mongo app for testing
 def appProperties = [
@@ -56,7 +56,7 @@ def groupProperties = [
 ]
 
 // Deploy Mongo app set in properties above
-//app.deployApp(appProperties)
+app.deployApp(appProperties)
 
 // Wait to restart to Marathon doesn't get mad
 sleep(1000)
@@ -71,7 +71,7 @@ sleep(1000)
 //sleep(5000)
 
 // Delete Mongo app
-//app.destroyApp(appProperties.appId)
+app.destroyApp(appProperties.appId)
 
-app.deployLoadBalancer('external')
+// app.deployLoadBalancer('external')
 

--- a/Main.groovy
+++ b/Main.groovy
@@ -1,8 +1,7 @@
-
 package myPackage
 
 app = new Api()
-app.init('http://localhost')
+app.init('http://localhost', true)
 
 // Mongo app for testing
 def appProperties = [
@@ -62,16 +61,22 @@ app.deployApp(appProperties)
 sleep(1000)
 
 // Restart Mongo app
-//app.restartApp(appProperties.appId)
+app.restartApp(appProperties.appId)
 
-//sleep(5000)
+// Wait for Marathon to do stuff
+sleep(5000)
 
-//app.scaleApp(appProperties.appId, scaleUp)
+// Scale app for show
+app.scaleApp(appProperties.appId, scaleUp)
 
-//sleep(5000)
+// More waiting
+sleep(5000)
 
 // Delete Mongo app
 app.destroyApp(appProperties.appId)
 
 // app.deployLoadBalancer('external')
+// app.deployLoadBalancer('internal')
 
+app.checkHasLoadBalancer('external')
+app.checkHasLoadBalancer('internal')


### PR DESCRIPTION
If 'autoDeployMLB' is set to 'true' on init(), then it will query for a task with a matching name (name specifies type). If one does not exist, then deploy one of the necessary type (internal/external)

Note: In the future, this could be done better by getting a list of all tasks and searching those for something that matches, so that if a load balancer is created with another name, it can still be found. However, this is a 'meh' temp solution
